### PR TITLE
Fuse quantization into the DCT pass-2 store

### DIFF
--- a/lib/block_coding.cpp
+++ b/lib/block_coding.cpp
@@ -92,22 +92,13 @@ void encode_mcus(std::vector<int16_t *> &in, int width, const int mcu_height, co
 
   if (nc == 3) {  // color
     for (int k = 0; k < num_mcus; k += mcu_skip) {
-      // DCT, Quantization
+      // Fused DCT + quantize, per block.
       for (int i = mcu_skip; i > 0; --i) {
-        dct2_core(block0);
+        dct2_core(block0, qtable);
         block0 += DCTSIZE2;
       }
-      dct2_core(block1);
-      dct2_core(block2);
-
-      block0 = in[0] + k * DCTSIZE2;
-
-      for (int i = mcu_skip; i > 0; --i) {
-        quantize_core(block0, qtable);
-        block0 += DCTSIZE2;
-      }
-      quantize_core(block1, qtable + DCTSIZE2);
-      quantize_core(block2, qtable + DCTSIZE2);
+      dct2_core(block1, qtable + DCTSIZE2);
+      dct2_core(block2, qtable + DCTSIZE2);
 
       block0 = in[0] + k * DCTSIZE2;
 
@@ -125,10 +116,8 @@ void encode_mcus(std::vector<int16_t *> &in, int width, const int mcu_height, co
   } else {  // monochrome
     for (int k = 0; k < num_mcus; k += mcu_skip * 2) {
       // Process two blocks within a single iteration for the speed
-      dct2_core(block0);
-      dct2_core(block0 + DCTSIZE2);
-      quantize_core(block0, qtable);
-      quantize_core(block0 + DCTSIZE2, qtable);
+      dct2_core(block0, qtable);
+      dct2_core(block0 + DCTSIZE2, qtable);
       encode_block(block0, tab_Y, prev_dc[0], enc);
       encode_block(block0 + DCTSIZE2, tab_Y, prev_dc[0], enc);
       block0 += DCTSIZE2 * 2;

--- a/lib/dct.cpp
+++ b/lib/dct.cpp
@@ -23,7 +23,11 @@ static const int16_t a3 = static_cast<int16_t>(round((c2 + c6 - 1.0) * (1 << 15)
 
 HWY_ALIGN static const int16_t coeff[] = {a0, a1, a2, a3, 0, 0, 0, 0};
 
-void dct2_core(int16_t *HWY_RESTRICT data) {
+// Fused forward 8x8 DCT + quantization. Pass-2 row vectors are multiplied by
+// the corresponding row of `qtable` (8 int16 values per row, DCTSIZE-strided)
+// before being stored, eliminating the separate quantize pass that used to
+// follow this function.
+void dct2_core(int16_t *HWY_RESTRICT data, const int16_t *HWY_RESTRICT qtable) {
 #if HWY_TARGET != HWY_SCALAR
   HWY_CAPPED(int16_t, 8) s16;
   //  HWY_CAPPED(int32_t, 4) s32;
@@ -222,14 +226,18 @@ void dct2_core(int16_t *HWY_RESTRICT data) {
   row1 = Add(z11, z4);
   row7 = Sub(z11, z4);
 
-  Store(row0, s16, data + 0 * DCTSIZE);
-  Store(row1, s16, data + 1 * DCTSIZE);
-  Store(row2, s16, data + 2 * DCTSIZE);
-  Store(row3, s16, data + 3 * DCTSIZE);
-  Store(row4, s16, data + 4 * DCTSIZE);
-  Store(row5, s16, data + 5 * DCTSIZE);
-  Store(row6, s16, data + 6 * DCTSIZE);
-  Store(row7, s16, data + 7 * DCTSIZE);
+  // Fused quantize: multiply each pass-2 row by the matching qtable row before
+  // storing. Same numeric result as a separate quantize pass that does
+  // MulFixedPoint15(data[i], qtable[i]) per element, with one less round-trip
+  // through memory.
+  Store(MulFixedPoint15(row0, Load(s16, qtable + 0 * DCTSIZE)), s16, data + 0 * DCTSIZE);
+  Store(MulFixedPoint15(row1, Load(s16, qtable + 1 * DCTSIZE)), s16, data + 1 * DCTSIZE);
+  Store(MulFixedPoint15(row2, Load(s16, qtable + 2 * DCTSIZE)), s16, data + 2 * DCTSIZE);
+  Store(MulFixedPoint15(row3, Load(s16, qtable + 3 * DCTSIZE)), s16, data + 3 * DCTSIZE);
+  Store(MulFixedPoint15(row4, Load(s16, qtable + 4 * DCTSIZE)), s16, data + 4 * DCTSIZE);
+  Store(MulFixedPoint15(row5, Load(s16, qtable + 5 * DCTSIZE)), s16, data + 5 * DCTSIZE);
+  Store(MulFixedPoint15(row6, Load(s16, qtable + 6 * DCTSIZE)), s16, data + 6 * DCTSIZE);
+  Store(MulFixedPoint15(row7, Load(s16, qtable + 7 * DCTSIZE)), s16, data + 7 * DCTSIZE);
 #else
   int32_t tmp0, tmp1, tmp2, tmp3, tmp4, tmp5, tmp6, tmp7;
   int32_t tmp10, tmp11, tmp12, tmp13;
@@ -336,6 +344,11 @@ void dct2_core(int16_t *HWY_RESTRICT data) {
     dataptr[DCTSIZE * 7] = static_cast<int16_t>((z11 - z4));
 
     dataptr++; /* advance pointer to next column */
+  }
+
+  /* Quantize (scalar fallback — kept correct for the rarely-used SCALAR target). */
+  for (int i = 0; i < DCTSIZE2; ++i) {
+    data[i] = static_cast<int16_t>(((int32_t)data[i] * qtable[i] + half) >> 15);
   }
 #endif
 }


### PR DESCRIPTION
## Summary

`dct2_core()` now takes a `qtable` pointer and multiplies each pass-2 row vector by the matching qtable row before the final `Store`. The separate `quantize_core()` call disappears from `encode_mcus()` entirely (both color and monochrome paths), saving one full memory round-trip over the 64-int16 block per call.

## Behavior

Numerically unchanged: `dct_value × qtable / 2^15` with rounding matches the previous `quantize_core()` semantics exactly.

| Mode | ST byte-identical | MT byte-identical |
|---|---|---|
| 444 / 422 / 411 / 440 / 420 / 410 / GRAY | ✓ | ✓ |

Verified against pre-PR baselines on `u10_8bit.ppm` (4K, 8.29 MP).

## Performance

**Apple Silicon ST benchmark** (5 runs each):

| Mode | Pre-fusion | Post-fusion | Δ |
|---|---|---|---|
| 444 | ~468 MP/s | ~477 | +1.9% |
| 420 | ~688 | ~696 | +1.2% |
| GRAY | ~806 | ~809 | within noise |

**x86 (Ryzen 9 9950X) ST benchmark**: within run-to-run noise — the OoO engine + L1 cache absorb the saved memory round-trip on this CPU.

The win is modest on these high-end cores. Plausibly larger on smaller / older cores where the L1 round-trip is more expensive. The bigger benefit, IMO, is the structural simplification — `encode_mcus()` no longer has a separate quantize pass.

## Notes

- `quantization.cpp::quantize_core()` is now unreferenced. Left in place for now to keep this commit minimal; can be removed in a follow-up cleanup.
- The scalar fallback (`HWY_TARGET == HWY_SCALAR`) keeps a separate quantize loop after pass 2 — equivalent output, no perf win on that path, but it stays correct.

## Test plan
- [x] Build clean
- [x] All 7 chroma modes byte-identical in single-thread
- [x] All 7 chroma modes byte-identical in multi-thread
- [x] x86 build clean and byte-identical
- [x] Apple A/B benchmark (5 runs/mode)
- [x] x86 A/B benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)